### PR TITLE
Support for version-based code generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
           # This is the minimum supported Rust version of this crate.
           # When updating this, the reminder to update the minimum supported Rust version in README.md.
           - 1.31.0
+          - 1.33.0
+          - 1.39.0
           - stable
           - beta
           - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ members = ["test_suite"]
 [lib]
 proc-macro = true
 
+[build-dependencies]
+version_check = "0.9.2"
+
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"

--- a/README.md
+++ b/README.md
@@ -29,59 +29,33 @@ The current const_fn requires Rust 1.31 or later.
 
 ## Examples
 
-When using like the following functions to control unstable features:
-
-```toml
-[features]
-const_unstable = []
-```
-
-It can be written as follows:
-
 ```rust
-#![cfg_attr(feature = "const_unstable", feature(const_fn))]
 use const_fn::const_fn;
 
-pub struct Foo<T> {
-    x:T,
+// 1.36 and later compiler (including beta and nightly)
+#[const_fn("1.36")]
+pub const fn version() {
+    /* ... */
 }
 
-impl<T: Iterator> Foo<T> {
-    /// Constructs a new `Foo`.
-    #[const_fn(feature = "const_unstable")]
-    pub const fn new(x: T) -> Self {
-        Self { x }
-    }
-}
-```
-
-Code like this will be generated:
-
-```rust
-#![cfg_attr(feature = "const_unstable", feature(const_fn))]
-
-pub struct Foo<T> {
-    x:T,
+// nightly compiler (including dev build)
+#[const_fn(nightly)]
+pub const fn nightly() {
+    /* ... */
 }
 
-impl<T: Iterator> Foo<T> {
-    /// Constructs a new `Foo`.
-    #[cfg(feature = "const_unstable")]
-    pub const fn new(x: T) -> Self {
-        Self { x }
-    }
+// `cfg(...)`
+#[const_fn(cfg(...))]
+pub const fn cfg() {
+    /* ... */
+}
 
-    /// Constructs a new `Foo`.
-    #[cfg(not(feature = "const_unstable"))]
-    pub fn new(x: T) -> Self {
-        Self { x }
-    }
+// `cfg(feature = "...")`
+#[const_fn(feature = "...")]
+pub const fn feature() {
+    /* ... */
 }
 ```
-
-See [test_suite] for more examples.
-
-[test_suite]: https://github.com/taiki-e/const_fn/tree/master/test_suite
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,28 @@
+use std::{env, fs, path::PathBuf};
+
+fn main() {
+    let version = match Version::new() {
+        Some(version) => format!("{:#?}\n", version),
+        None => panic!("unexpected output from `rustc --version`"),
+    };
+
+    let out_dir = env::var_os("OUT_DIR").map(PathBuf::from).expect("OUT_DIR not set");
+    let out_file = out_dir.join("version.rs");
+    fs::write(out_file, version).expect("failed to write version.rs");
+}
+
+#[derive(Debug)]
+struct Version {
+    minor: u16,
+    patch: u16,
+    nightly: bool,
+}
+
+impl Version {
+    fn new() -> Option<Self> {
+        let (version, channel, _date) = version_check::triple()?;
+        let (_major, minor, patch) = version.to_mmp();
+        let nightly = channel.is_nightly() || channel.is_dev();
+        Some(Version { minor, patch, nightly })
+    }
+}

--- a/test_suite/build.rs
+++ b/test_suite/build.rs
@@ -9,13 +9,13 @@ fn main() {
     };
 
     if minor >= 31 || nightly {
-        println!("cargo:rustc-cfg=min_const_fn");
+        println!("cargo:rustc-cfg=has_min_const_fn");
     }
     if minor >= 33 || nightly {
-        println!("cargo:rustc-cfg=const_let");
+        println!("cargo:rustc-cfg=has_const_let");
     }
     if minor >= 39 || nightly {
-        println!("cargo:rustc-cfg=const_vec_new");
+        println!("cargo:rustc-cfg=has_const_vec_new");
     }
     if nightly {
         println!("cargo:rustc-cfg=const_unstable");

--- a/test_suite/tests/test.rs
+++ b/test_suite/tests/test.rs
@@ -1,75 +1,162 @@
 #![cfg_attr(const_unstable, feature(const_fn))]
 #![warn(rust_2018_idioms, single_use_lifetimes)]
-#![allow(dead_code)]
 
-use const_fn::const_fn;
+pub mod version {
+    use const_fn::const_fn;
 
-#[test]
-fn test_variables() {
-    assert!(const_min("variables") == "variables");
-    assert_eq!(const_let("variables"), "variables");
-    assert_eq!(const_vec_new::<u8>(), Vec::new());
-}
-
-// min_const_fn (rust 1.31+)
-
-#[const_fn(min_const_fn)]
-const fn const_min<T>(x: T) -> T {
-    x
-}
-
-#[cfg(min_const_fn)]
-const CONST_MIN: &str = const_min("min_const_fn");
-
-#[cfg(min_const_fn)]
-#[test]
-fn test_const_min() {
-    assert!(CONST_MIN == "min_const_fn");
-    assert_eq!(const_let("min_const_fn"), "min_const_fn");
-    assert_eq!(const_vec_new::<u8>(), Vec::new());
-}
-
-// const_let (rust 1.33+)
-
-#[allow(clippy::let_and_return)]
-#[const_fn(const_let)]
-const fn const_let<T>(x: T) -> T {
-    let y = const_min(x);
-    y
-}
-
-#[cfg(const_let)]
-const CONST_LET: &str = const_let("const_let");
-
-#[cfg(const_let)]
-#[test]
-fn test_const_let() {
-    assert!(CONST_LET == "const_let");
-    assert_eq!(const_vec_new::<u8>(), Vec::new());
-}
-
-// const_vec_new (rust 1.39+)
-
-#[const_fn(const_vec_new)]
-const fn const_vec_new<T>() -> Vec<T> {
-    Vec::new()
-}
-
-#[cfg(const_vec_new)]
-const CONST_VEC_NEW: Vec<u8> = const_vec_new();
-
-// const_fn (rust nightly)
-
-struct A<T> {
-    x: T,
-}
-
-impl<T: IntoIterator> A<T> {
-    #[const_fn(const_unstable)]
-    const fn const_unstable(x: T) -> Self {
-        Self { x }
+    #[test]
+    fn test_variables() {
+        assert!(const_min("variables") == "variables");
+        assert_eq!(const_let("variables"), "variables");
+        assert_eq!(const_vec_new::<u8>(), Vec::new());
+        assert_eq!(A::const_unstable(const_vec_new::<u8>()), A(Vec::new()));
     }
+
+    // min_const_fn (rust 1.31+)
+
+    #[const_fn("1.31")]
+    const fn const_min<T>(x: T) -> T {
+        x
+    }
+
+    #[cfg(has_min_const_fn)]
+    const CONST_MIN: &str = const_min("min_const_fn");
+
+    #[cfg(has_min_const_fn)]
+    #[test]
+    fn test_const_min() {
+        assert!(CONST_MIN == "min_const_fn");
+        assert_eq!(const_let("min_const_fn"), "min_const_fn");
+        assert_eq!(const_vec_new::<u8>(), Vec::new());
+    }
+
+    // const_let (rust 1.33+)
+
+    #[allow(clippy::let_and_return)]
+    #[const_fn("1.33")]
+    const fn const_let<T>(x: T) -> T {
+        let y = const_min(x);
+        y
+    }
+
+    #[cfg(has_const_let)]
+    const CONST_LET: &str = const_let("const_let");
+
+    #[cfg(has_const_let)]
+    #[test]
+    fn test_const_let() {
+        assert!(CONST_LET == "const_let");
+        assert_eq!(const_vec_new::<u8>(), Vec::new());
+    }
+
+    // const_vec_new (rust 1.39+)
+
+    #[const_fn("1.39")]
+    const fn const_vec_new<T>() -> Vec<T> {
+        Vec::new()
+    }
+
+    #[cfg(has_const_vec_new)]
+    const CONST_VEC_NEW: Vec<u8> = const_vec_new();
+
+    #[cfg(has_const_vec_new)]
+    #[test]
+    fn test_const_vec_new() {
+        assert_eq!(CONST_VEC_NEW, Vec::new());
+    }
+
+    // const_fn (rust nightly)
+
+    #[derive(Debug, Eq, PartialEq)]
+    pub struct A<T>(T);
+
+    impl<T: IntoIterator> A<T> {
+        #[const_fn(nightly)]
+        const fn const_unstable(x: T) -> Self {
+            A(x)
+        }
+    }
+
+    #[cfg(const_unstable)]
+    pub const CONST_UNSTABLE: A<Vec<u8>> = A::const_unstable(const_vec_new());
 }
 
-#[cfg(const_unstable)]
-const CONST_UNSTABLE: A<Vec<u8>> = A::const_unstable(const_vec_new());
+pub mod cfg {
+    use const_fn::const_fn;
+
+    #[test]
+    fn test_variables() {
+        assert!(const_min("variables") == "variables");
+        assert_eq!(const_let("variables"), "variables");
+        assert_eq!(const_vec_new::<u8>(), Vec::new());
+        assert_eq!(A::const_unstable(const_vec_new::<u8>()), A(Vec::new()));
+    }
+
+    // min_const_fn (rust 1.31+)
+
+    #[const_fn(cfg(has_min_const_fn))]
+    const fn const_min<T>(x: T) -> T {
+        x
+    }
+
+    #[cfg(has_min_const_fn)]
+    pub const CONST_MIN: &str = const_min("min_const_fn");
+
+    #[cfg(has_min_const_fn)]
+    #[test]
+    fn test_const_min() {
+        assert!(CONST_MIN == "min_const_fn");
+        assert_eq!(const_let("min_const_fn"), "min_const_fn");
+        assert_eq!(const_vec_new::<u8>(), Vec::new());
+    }
+
+    // const_let (rust 1.33+)
+
+    #[allow(clippy::let_and_return)]
+    #[const_fn(cfg(has_const_let))]
+    const fn const_let<T>(x: T) -> T {
+        let y = const_min(x);
+        y
+    }
+
+    #[cfg(has_const_let)]
+    const CONST_LET: &str = const_let("const_let");
+
+    #[cfg(has_const_let)]
+    #[test]
+    fn test_const_let() {
+        assert!(CONST_LET == "const_let");
+        assert_eq!(const_vec_new::<u8>(), Vec::new());
+    }
+
+    // const_vec_new (rust 1.39+)
+
+    #[const_fn(cfg(has_const_vec_new))]
+    const fn const_vec_new<T>() -> Vec<T> {
+        Vec::new()
+    }
+
+    #[cfg(has_const_vec_new)]
+    const CONST_VEC_NEW: Vec<u8> = const_vec_new();
+
+    #[cfg(has_const_vec_new)]
+    #[test]
+    fn test_const_vec_new() {
+        assert_eq!(CONST_VEC_NEW, Vec::new());
+    }
+
+    // const_fn (rust nightly)
+
+    #[derive(Debug, Eq, PartialEq)]
+    pub struct A<T>(T);
+
+    impl<T: IntoIterator> A<T> {
+        #[const_fn(cfg(const_unstable))]
+        const fn const_unstable(x: T) -> Self {
+            A(x)
+        }
+    }
+
+    #[cfg(const_unstable)]
+    pub const CONST_UNSTABLE: A<Vec<u8>> = A::const_unstable(const_vec_new());
+}


### PR DESCRIPTION
This rewrites the const_fn attribute to support the following four syntaxes:

```rust
use const_fn::const_fn;

// 1.36 and later compiler (including beta and nightly)
#[const_fn("1.36")]
pub const fn version() {
    /* ... */
}

// nightly compiler (including dev build)
#[const_fn(nightly)]
pub const fn nightly() {
    /* ... */
}

// `cfg(...)`
#[const_fn(cfg(...))]
pub const fn cfg() {
    /* ... */
}

// `cfg(feature = "...")`
#[const_fn(feature = "...")]
pub const fn feature() {
    /* ... */
}
```

This does not provide any special support for beta. This is because unlike nighty there are no unstable features (features available in beta are already stabilized, so I think it is preferable to specify that version).

Closes #15 