### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.4.0] - 2020-08-25
+
+* [Add support for version-based code generation.](https://github.com/taiki-e/const_fn/pull/17) The following conditions are available:
+
+  ```rust
+  use const_fn::const_fn;
+
+  // function is `const` on specified version and later compiler (including beta and nightly)
+  #[const_fn("1.36")]
+  pub const fn version() {
+      /* ... */
+  }
+
+  // function is `const` on nightly compiler (including dev build)
+  #[const_fn(nightly)]
+  pub const fn nightly() {
+      /* ... */
+  }
+
+  // function is `const` if `cfg(...)` is true
+  #[const_fn(cfg(...))]
+  pub const fn cfg() {
+      /* ... */
+  }
+
+  // function is `const` if `cfg(feature = "...")` is true
+  #[const_fn(feature = "...")]
+  pub const fn feature() {
+      /* ... */
+  }
+  ```
+
+* Improve compile time by removing proc-macro related dependencies ([#18](https://github.com/taiki-e/const_fn/pull/18), [#20](https://github.com/taiki-e/const_fn/pull/20)).
+
 ## [0.3.1] - 2019-12-09
 
 * Updated `syn-mid` to 0.5.
@@ -56,7 +90,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 Initial release
 
-[Unreleased]: https://github.com/taiki-e/const_fn/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/taiki-e/const_fn/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/taiki-e/const_fn/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/taiki-e/const_fn/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/taiki-e/const_fn/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/taiki-e/const_fn/compare/v0.2.0...v0.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const_fn"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"
@@ -11,7 +11,7 @@ keywords = ["macros", "attribute", "const", "static"]
 categories = ["rust-patterns"]
 readme = "README.md"
 description = """
-An attribute for easy generation of a const function with conditional compilations.
+An attribute for easy generation of const functions with conditional compilations.
 """
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [rustc-badge]: https://img.shields.io/badge/rustc-1.31+-lightgray.svg
 [rustc-url]: https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html
 
-An attribute for easy generation of a const function with conditional compilations.
+An attribute for easy generation of const functions with conditional compilations.
 
 ## Usage
 
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-const_fn = "0.3"
+const_fn = "0.4"
 ```
 
 The current const_fn requires Rust 1.31 or later.
@@ -32,25 +32,25 @@ The current const_fn requires Rust 1.31 or later.
 ```rust
 use const_fn::const_fn;
 
-// 1.36 and later compiler (including beta and nightly)
+// function is `const` on specified version and later compiler (including beta and nightly)
 #[const_fn("1.36")]
 pub const fn version() {
     /* ... */
 }
 
-// nightly compiler (including dev build)
+// function is `const` on nightly compiler (including dev build)
 #[const_fn(nightly)]
 pub const fn nightly() {
     /* ... */
 }
 
-// `cfg(...)`
+// function is `const` if `cfg(...)` is true
 #[const_fn(cfg(...))]
 pub const fn cfg() {
     /* ... */
 }
 
-// `cfg(feature = "...")`
+// function is `const` if `cfg(feature = "...")` is true
 #[const_fn(feature = "...")]
 pub const fn feature() {
     /* ... */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,19 +5,19 @@
 //! ```rust
 //! use const_fn::const_fn;
 //!
-//! // 1.36 and later compiler (including beta and nightly)
+//! // function is `const` on specified version and later compiler (including beta and nightly)
 //! #[const_fn("1.36")]
 //! pub const fn version() {
 //!     /* ... */
 //! }
 //!
-//! // nightly compiler (including dev build)
+//! // function is `const` on nightly compiler (including dev build)
 //! #[const_fn(nightly)]
 //! pub const fn nightly() {
 //!     /* ... */
 //! }
 //!
-//! // `cfg(...)`
+//! // function is `const` if `cfg(...)` is true
 //! # #[cfg(any())]
 //! #[const_fn(cfg(...))]
 //! # pub fn _cfg() { unimplemented!() }
@@ -25,14 +25,14 @@
 //!     /* ... */
 //! }
 //!
-//! // `cfg(feature = "...")`
+//! // function is `const` if `cfg(feature = "...")` is true
 //! #[const_fn(feature = "...")]
 //! pub const fn feature() {
 //!     /* ... */
 //! }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/const_fn/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/const_fn/0.4.0")]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms, single_use_lifetimes), allow(dead_code))


### PR DESCRIPTION
Changes:

* [Add support for version-based code generation.](https://github.com/taiki-e/const_fn/pull/17) The following conditions are available:

  ```rust
  use const_fn::const_fn;

  // function is `const` on specified version and later compiler (including beta and nightly)
  #[const_fn("1.36")]
  pub const fn version() {
      /* ... */
  }

  // function is `const` on nightly compiler (including dev build)
  #[const_fn(nightly)]
  pub const fn nightly() {
      /* ... */
  }

  // function is `const` if `cfg(...)` is true
  #[const_fn(cfg(...))]
  pub const fn cfg() {
      /* ... */
  }

  // function is `const` if `cfg(feature = "...")` is true
  #[const_fn(feature = "...")]
  pub const fn feature() {
      /* ... */
  }
  ```

* Improve compile time by removing proc-macro related dependencies ([#18](https://github.com/taiki-e/const_fn/pull/18), [#20](https://github.com/taiki-e/const_fn/pull/20)).