### PR TITLE
Do not fail to compile if unable to determine rustc version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+* `const_fn` no longer fails to compile if unable to determine rustc version. Instead, it now displays a warning.
+
+* [`const_fn` no longer relies on debug print format.](https://github.com/taiki-e/const_fn/pull/30)
+
 ## [0.4.2] - 2020-08-31
 
 * [Improve error messages when failed to parse version information.](https://github.com/taiki-e/const_fn/pull/26)

--- a/build.rs
+++ b/build.rs
@@ -15,14 +15,21 @@ fn main() {
     let rustc = env::var_os("RUSTC").map_or_else(|| "rustc".into(), PathBuf::from);
     let version = match Version::from_rustc(&rustc) {
         Ok(version) => version.print(),
-        Err(e) => panic!("{}", e),
+        Err(e) => {
+            println!(
+                "cargo:warning={}: unable to determine rustc version: {}",
+                env!("CARGO_PKG_NAME"),
+                e
+            );
+            return;
+        }
     };
 
     let out_dir = env::var_os("OUT_DIR").map(PathBuf::from).expect("OUT_DIR not set");
     let out_file = out_dir.join("version.rs");
     fs::write(out_file, version).expect("failed to write version.rs");
 
-    // Mark build script has been run.
+    // Mark as build script has been run successfully.
     println!("cargo:rustc-cfg=const_fn_has_build_script");
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,13 +116,13 @@ fn expand(arg: Arg, mut func: Func) -> TokenStream {
             tokens
         }
         Arg::Version(req) => {
-            if req.major > 1 || VERSION.as_ref().map_or(true, |v| req.minor > v.minor) {
+            if req.major > 1 || req.minor > VERSION.minor {
                 func.print_const = false;
             }
             func.to_token_stream()
         }
         Arg::Nightly => {
-            func.print_const = VERSION.as_ref().map_or(false, |v| v.nightly);
+            func.print_const = VERSION.nightly;
             func.to_token_stream()
         }
     }
@@ -228,6 +228,7 @@ struct Version {
 }
 
 #[cfg(const_fn_has_build_script)]
-const VERSION: Option<Version> = Some(include!(concat!(env!("OUT_DIR"), "/version.rs")));
+const VERSION: Version = include!(concat!(env!("OUT_DIR"), "/version.rs"));
+// If build script has not run or unable to determine version, it is considered as Rust 1.0.
 #[cfg(not(const_fn_has_build_script))]
-const VERSION: Option<Version> = None;
+const VERSION: Version = Version { minor: 0, nightly: false };


### PR DESCRIPTION
`const_fn` no longer fails to compile if unable to determine rustc version. Instead, it now displays a warning.