### PR TITLE
Remove extension from $OUT_DIR/version.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -26,7 +26,7 @@ fn main() {
     };
 
     let out_dir = env::var_os("OUT_DIR").map(PathBuf::from).expect("OUT_DIR not set");
-    let out_file = out_dir.join("version.rs");
+    let out_file = out_dir.join("version");
     fs::write(out_file, version).expect("failed to write version.rs");
 
     // Mark as build script has been run successfully.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ use crate::{
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// An attribute for easy generation of const functions with conditional compilations.
+///
 /// See crate level documentation for details.
 #[proc_macro_attribute]
 pub fn const_fn(args: TokenStream, input: TokenStream) -> TokenStream {
@@ -227,7 +228,7 @@ struct Version {
 }
 
 #[cfg(const_fn_has_build_script)]
-const VERSION: Version = include!(concat!(env!("OUT_DIR"), "/version.rs"));
+const VERSION: Version = include!(concat!(env!("OUT_DIR"), "/version"));
 // If build script has not run or unable to determine version, it is considered as Rust 1.0.
 #[cfg(not(const_fn_has_build_script))]
 const VERSION: Version = Version { minor: 0, nightly: false };


### PR DESCRIPTION
This file is not a valid rust file by itself. This is usually fine as it
is generated to the target directory, but it is not compatible with
[rough commands like ignore gitignore and search for rust files](https://github.com/tokio-rs/tokio/blob/tokio-0.3.4/CONTRIBUTING.md#cargo-commands).