### PR TITLE
Detect -Z assume-incomplete-release flag

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,9 @@ fn expand(arg: Arg, mut func: Func) -> TokenStream {
             tokens
         }
         Arg::Version(req) => {
-            if req.major > 1 || req.minor > VERSION.minor {
+            if req.major > 1
+                || req.minor + (cfg!(const_fn_assume_incomplete_release) as u32) > VERSION.minor
+            {
                 func.print_const = false;
             }
             func.to_token_stream()


### PR DESCRIPTION
- Assume that nightly is complete by default. This is the same as the current behavior.
- If `-Z assume-incomplete-release` flag is specified, detect it from `RUSTFLAGS` by build script and assume that nightly is incomplete.

See #27 for more.

Closes #27