### PR TITLE
Fix detection of `-Z assume-incomplete-release`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Fix detection of `-Z assume-incomplete-release` in recent nightly compilers.
+
 ## [0.4.8] - 2021-05-19
 
 - [Fix parsing of macro metavariable in attribute arguments.](https://github.com/taiki-e/const_fn/pull/37)
@@ -120,7 +122,7 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [0.1.4] - 2019-02-15
 
-**Note: This release has been yanked.**
+**NOTE:** This release has been yanked.
 
 - Reduce compilation time
 

--- a/build.rs
+++ b/build.rs
@@ -111,8 +111,9 @@ fn assume_incomplete_release() -> bool {
     //
     //     -Zassume-incomplete-release
 
-    if let Some(rustflags) = env::var_os("RUSTFLAGS") {
-        for mut flag in rustflags.to_string_lossy().split(' ') {
+    // https://github.com/rust-lang/cargo/issues/10111
+    if let Some(rustflags) = env::var_os("CARGO_ENCODED_RUSTFLAGS") {
+        for mut flag in rustflags.to_string_lossy().split('\x1f') {
             if flag.starts_with("-Z") {
                 flag = &flag["-Z".len()..];
             }


### PR DESCRIPTION
Since 1.55, cargo pass `CARGO_ENCODED_RUSTFLAGS` instead of `RUSTFLAGS` to build-scripts: https://github.com/rust-lang/cargo/issues/10111